### PR TITLE
Remove SetDocName

### DIFF
--- a/app/otbAggregate.cpp
+++ b/app/otbAggregate.cpp
@@ -5,7 +5,6 @@ void otb::Wrapper::Aggregate::DoInit()
 	SetName("Aggregate");
 	SetDescription("This application assign a class on each object of a segmentation by majority voting on a pixel-based classification.");
 
-	SetDocName("Aggregate");
 	SetDocLongDescription("The aim of this application is to merge the result of a segmentation with a pixel-based image classification in order to produce an object-oriented image classification. The input segmentation is a labeled image, typically the result provided by the OTB application LSMSSegmentation. The output is a vector dataset containing objects and the corresponding class in the attribute table. Connected regions belonging to the same class are merged. This application could be used at the last step of the LSMS pipeline in replacement of the application LSMSVectorization.");
 	SetDocLimitations("Input classification and labeled image should have identical resolution and footprint");
 	SetDocAuthors("Lucie Bouillot");

--- a/app/otbObjectsRadiometricStatistics.cpp
+++ b/app/otbObjectsRadiometricStatistics.cpp
@@ -5,7 +5,6 @@ void otb::Wrapper::ObjectsRadiometricStatistics::DoInit()
 	SetName("ObjectsRadiometricStatistics");
 	SetDescription("Compute features attributes of a vector dataset over an image.");
 
-	SetDocName("ObjectsRadiometricStatistics");
 	SetDocLongDescription("This application computes radiometric and shapes attributes on a vector dataset, using an image. The results are stored in the attribute table. Shape attributes are : number of pixels, flatness, roundness, elongation, perimeter. Radiometric attributes are for each band of the input image : mean, standard-deviation, median, variance, kurtosis, skewness.");
 	SetDocLimitations("None");
 	SetDocAuthors("Arnaud Durand");


### PR DESCRIPTION
This MR allow the remote module compilation as there is no more `SetDocName` function on otb develop branch.